### PR TITLE
Grammar Correction: You must be logged in to vote! 5-links-and-voting page

### DIFF
--- a/hackernews/links/schema.py
+++ b/hackernews/links/schema.py
@@ -87,7 +87,7 @@ class CreateVote(graphene.Mutation):
     def mutate(self, info, link_id):
         user = info.context.user
         if user.is_anonymous:
-            raise GraphQLError('You must be logged to vote!')
+            raise GraphQLError('You must be logged in to vote!')
 
         link = Link.objects.filter(id=link_id).first()
         if not link:


### PR DESCRIPTION
changed to "You must be logged in to vote!" from  "You must be logged to vote!"