### PR TITLE
Curly braces in Graphene Middleware Import

### DIFF
--- a/hackernews/hackernews/settings.py
+++ b/hackernews/hackernews/settings.py
@@ -133,7 +133,7 @@ STATIC_URL = '/static/'
 
 GRAPHENE = {
     'SCHEMA': 'hackernews.schema.schema',
-    'MIDDLEWARE': [
+    'MIDDLEWARE': {
         'graphql_jwt.middleware.JSONWebTokenMiddleware',
-    ],
+    },
 }


### PR DESCRIPTION
This is my very first pull request. I have got no clue how all of this works, but I couldn find any other way to bring a potential bug to your attention.

I am not sure why the imports works with curly braces but they do. I thought you might want to have look at it any either discard my suggestion or maybe find it useful.

Thanks.